### PR TITLE
BODATA-3202 Fix reading empty files

### DIFF
--- a/lib/hdfs.js
+++ b/lib/hdfs.js
@@ -81,17 +81,17 @@ libhdfs3.prototype.read = function(path, cb) {
     stream._read = function () {
         if (eof) {
             // If end of file, stop reading
-            return stream.push(null);
+            stream.push(null);
         } else {
             file.read(function(err, data) {
                 if (err) {
-                    return stream.emit('error', err);
+                    stream.emit('error', err);
                 } else if (data && data.bytesRead > 0) {
                     eof = data.eof;
                     stream.push(data.data);
                 } else {
                     // If no bytes were read, stop reading. This statement can be reached when the file is empty.
-                    return stream.push(null);
+                    stream.push(null);
                 }             
             });
         }

--- a/lib/hdfs.js
+++ b/lib/hdfs.js
@@ -79,18 +79,22 @@ libhdfs3.prototype.read = function(path, cb) {
     var stream = new Readable({ highWaterMark: 64 * 1024 });
     var eof = false;
     stream._read = function () {
-        file.read(function(err, data) {
-            if (err) {
-                return stream.emit('error', err);
-            }
-            if (eof) {
-                return stream.push(null);
-            }
-            if (data.bytesRead > 0) {
-                stream.push(data.data);
-            }
-            eof = data.eof;
-        });
+        if (eof) {
+            // If end of file, stop reading
+            return stream.push(null);
+        } else {
+            file.read(function(err, data) {
+                if (err) {
+                    return stream.emit('error', err);
+                } else if (data && data.bytesRead > 0) {
+                    eof = data.eof;
+                    stream.push(data.data);
+                } else {
+                    // If no bytes were read, stop reading. This statement can be reached when the file is empty.
+                    return stream.push(null);
+                }             
+            });
+        }
     };
     cb(undefined, stream);
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libhdfs3",
   "description": "libhdfs3 bindings for node",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "main": "lib/hdfs.js",
   "homepage": "http://github.com/immuta/node-libhdfs3/",
   "repository": {


### PR DESCRIPTION
@immuta/developers 

This PR fixes a condition where the HDFS client would time out when trying to read an empty file. 
 I noticed this when performing a datasource test and the first file found for reading was an empty file.  Also noticed that we perform an unnecessary read of the beginning of a file after EOF is reached, so we reworked that logic.