### PR TITLE
use link settings to set folder for dy lib

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,7 +13,11 @@
             ],
             'conditions' : [
                 [ 'OS == "linux"', { 'libraries' : [ '-lhdfs3' ], 'cflags' : [ '-g' ] }],
-                [ 'OS == "mac"', { 'libraries' : [ '-L/usr/local/lib', '-lhdfs3' ] }]
+                [ 'OS == "mac"', { 'link_settings': {
+                                        'libraries': ['-L/usr/local/lib/']
+                                    },
+                                    'libraries' : [ '-Lhdfs3' ] }
+                ]
             ]
         }
     ]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lib": "."
   },
   "engines": {
-    "node": ">=12.1.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "install": "node-gyp rebuild",


### PR DESCRIPTION
Honestly don't know why I needed to add this change to make the linker find the lib. 

I also found that adding `/user/local/lib` to the `DYLD_LIBRARY_PATH` env var worked when testing in this repo, but naught did not carry over the variable when running bodata. So if we dont like this fix we could probably update naught to honor `DYLD_LIBRARY_PATH` instead of changing this repo